### PR TITLE
Link chapter 3 (Comprehensions) in PWAA works index

### DIFF
--- a/home/src/works/20230718-python-warts-and-all.md
+++ b/home/src/works/20230718-python-warts-and-all.md
@@ -31,7 +31,7 @@ This series is structured as a mini-book — each post is a chapter, and each ch
 
 1. [Literal Data Structures](../../posts/2023/07/pwaa-1-literal-data-structures/)
 2. [The Python Data Model](../../posts/2023/07/pwaa-2-data-model/)
-3. Comprehensions *(coming soon)*
+3. [Comprehensions](../../posts/2026/02/pwaa-3-comprehensions/)
 4. Generators *(coming soon)*
 5. REPL *(coming soon)*
 6. Typing *(coming soon)*


### PR DESCRIPTION
The post was published but the works index still showed it as coming
soon. Updated to link to the published post at posts/2026/02/pwaa-3-comprehensions/.

https://claude.ai/code/session_01D2YkUFkLyYL1ss6XCEH55D