### PR TITLE
Add First Principles #7: Protect Flow State

### DIFF
--- a/home/src/posts/2026/02/first-principles-7-flow-state.md
+++ b/home/src/posts/2026/02/first-principles-7-flow-state.md
@@ -1,0 +1,113 @@
+---
+templateEngineOverride: njk,md
+metaTitle: First Principle - Protect Flow State
+metaDescription: Flow State is the founding engineer's highest-leverage resource. Here's how to protect it — for yourself and everyone around you.
+title: First Principle - Protect Flow State
+description: Flow State is the founding engineer's highest-leverage resource. Here's how to protect it — for yourself and everyone around you.
+featuredImg:
+subHeading: First Principle - Protect Flow State
+tags: ['first-principles', 'founding-engineer']
+date: 2026-02-23
+updated:
+published: true
+---
+
+<div class="col-start-3 col-end-9">
+
+# First Principle - Protect Flow State
+
+In [Post 2 of this series](/2023/07/first-principles-2-know-your-strengths/), I promised to write about Flow State. That was July 2023. It is now February 2026.
+
+I'm sorry. I was busy being in Flow State.
+
+(Mostly.)
+
+## What Is Flow?
+
+Mihaly Csikszentmihalyi[¹](#1) defined Flow in his 1990 book _Flow: The Psychology of Optimal Experience_. The idea is straightforward: Flow is the mental state of complete absorption in a challenging, intrinsically rewarding task. Time distorts. Self-consciousness disappears. Performance peaks.
+
+You've been there. The three-hour coding session that felt like twenty minutes. The design problem that dissolved in the shower. The debugging rabbit hole you couldn't climb out of — and didn't want to.
+
+Csikszentmihalyi identified the conditions that enable Flow:
+
+- **Clear goals** — you know what done looks like
+- **Immediate feedback** — you know how you're doing as you go
+- **Skill/challenge balance** — hard enough to be interesting, easy enough to be achievable
+- **Freedom from distraction** — the environment stops competing for your attention
+
+Sound simple? It is. Achieving it inside a startup is another matter entirely.
+
+## Why Founding Engineers Must Protect It
+
+In Post 2, I described Talents as the gateway to Flow. Here's the extension of that idea: **Flow is the highest-value state a knowledge worker can enter.**
+
+Paul Graham articulated this in 2009 with ["Maker's Schedule, Manager's Schedule"](http://www.paulgraham.com/makersschedule.html) — a single meeting can destroy an entire morning for someone who builds things. Cal Newport built a career on this idea with _Deep Work_ (2016). The underlying insight hasn't changed since Csikszentmihalyi in 1990; it's just Lindy[²](#2) wearing different clothes.
+
+Now consider what a founding engineer actually produces. It isn't code. It's _decisions with compounding consequences_. The data model you design in year one will outlast the startup. The API contract you set will be honored — or broken, at great cost — for years. The deployment pipeline you automate will shape how fast every engineer after you can ship.
+
+These decisions require Flow. You cannot design a durable system while triaging Slack.
+
+## The Enemies of Flow in a Startup
+
+The irony of a startup is that the urgency driving it is the exact force that destroys the conditions for good work.
+
+**Meetings.** The manager's schedule runs on appointments. Any hour can become a meeting. The maker's schedule runs on unbroken blocks. One afternoon standup at 3pm doesn't just cost thirty minutes — it costs the two hours of runway you needed to get to depth on either side of it.
+
+**Context switching.** Every Slack notification, every "quick question," every Jira comment lands like a rock in still water. Research puts the recovery time at roughly 23 minutes per interruption.[³](#3) Do the math on a typical startup workday.
+
+**Unclear work.** Flow requires knowing what done looks like. Vague tickets, undefined acceptance criteria, and "just figure it out" scope are Flow killers. This is why I put [Write Stuff Down](/2023/07/first-principles-1-write-stuff-down/) first in this series. The discipline of writing forces clarity, and clarity is a prerequisite for Flow.
+
+**Heroics.** When you are the only person who understands how something works, you get paged. Constantly. At 3am. On vacation. Hero culture is Flow's worst enemy because it makes every system incident a personal interrupt. I wrote about [Code is Liability](/2024/09/first-principles-5-code-is-liability/) and [Don't Break Consumers](/2024/10/first-principles-6-dont-break-consumers-ever/) — hero culture is the operational equivalent of that same problem. Concentration of knowledge is a liability.
+
+## How to Protect Flow
+
+Here is where it gets practical.
+
+### Technical moves
+
+**Automate the interruptible.** CI/CD pipelines, automated tests, runbooks, self-healing infrastructure. Every toil task you automate is a future interrupt you've preemptively eliminated. The founding engineer who builds reliable automation is protecting not just their own Flow but everyone's after them.
+
+**Design for self-service.** APIs, internal tools, and documentation that consumers can use without asking you a question. Every time someone has to Slack you to understand your system, that's a design failure — and a Flow interrupt for both of you. (See: [Don't Break Consumers](/2024/10/first-principles-6-dont-break-consumers-ever/).)
+
+**Boring deploys.** If deploys are exciting, something has gone wrong upstream. Feature flags, blue/green deployments, and incremental rollouts turn "ship" from a ceremony into a non-event. Non-events don't break Flow.
+
+### Cultural moves
+
+**Async by default.** Treat synchronous communication as the expensive option, not the default. Most Slack messages can be a document. Most standup updates can be a comment. Normalize writing things down — yes, again — and protecting unbroken blocks of time.
+
+**Core hours + no-meeting zones.** Pick 2–3 hours a day where no one schedules meetings. This is less a policy than a habit you model. When you block your calendar and emerge three hours later having shipped something, people pay attention.
+
+**Normalize "do not disturb."** Make it safe to be unavailable for a stretch. If your culture punishes someone for being unreachable for two hours, you have a culture problem, not a Slack problem.
+
+## The Founding Engineer's Responsibility
+
+Here is the part nobody tells you.
+
+You don't just protect your own Flow. Your highest-leverage job is **creating the conditions for everyone else's Flow**.
+
+This means writing clear tickets so other engineers have clear goals. It means reviewing PRs quickly so engineers get fast feedback and aren't blocked. It means making architectural decisions decisively, because ambiguity is a context-switch generator. It means building systems that don't require heroics to maintain — so your team isn't paged into the ground and can actually do deep work.
+
+Csikszentmihalyi called people who find Flow intrinsically "autotelic." They don't need external rewards to engage deeply with hard work. They find the work itself rewarding. Hire these people. Then build systems that protect their ability to do what they're already driven to do.
+
+Your job is to get out of their way — and to remove every obstacle between them and their best work.
+
+## tl;dr
+
+Flow State is the founding engineer's most precious resource. Not for sentimental reasons — because compounding decisions require depth, and depth requires Flow.
+
+Automate the interruptible. Write things down. Decide decisively. Build systems that don't page you at 3am. Hire people who love the work. Then protect their ability to do it.
+
+That's the leverage. Everything else is overhead.
+
+# Notes
+
+#### 1
+"Mihaly Csikszentmihalyi" is pronounced "me-high cheeks-sent-me-high." You're welcome. _Flow: The Psychology of Optimal Experience_ (1990) has been in print for 35 years. Lindy says it'll be around for 35 more.
+
+#### 2
+[Respect Lindy — First Principle 3](/2023/08/first-principles-3-lindy/)
+
+#### 3
+Gloria Mark, _Attention Span_ (2023). The original research is from her 2004 study at UC Irvine. It's been replicated enough times that I'm comfortable citing it in a blog post.
+
+</div>


### PR DESCRIPTION
New post in the founding engineer series making good on the promise
from Post 2 (July 2023) to write about Flow State. Covers Csikszentmihalyi's
conditions for flow, the startup enemies of deep work, and the founding
engineer's responsibility to protect flow for the whole team.

https://claude.ai/code/session_01TFvDTBUx7hZAVyJfyA6W4m