### PR TITLE
Add blog post: The Right Detail, Not More Detail

### DIFF
--- a/home/src/posts/2026/03/more-wonder-and-woe-with-ai.md
+++ b/home/src/posts/2026/03/more-wonder-and-woe-with-ai.md
@@ -81,3 +81,20 @@ Eric Evans, _Domain-Driven Design: Tackling Complexity in the Heart of Software_
 
 Dr. John, "Right Place Wrong Time" (1973). A song about timing, miscommunication, and having all the right ingredients in all the wrong arrangements. Also a perfect description of a five-phase project plan.
 
+---
+
+## LinkedIn
+
+The AI asked the right question during planning. I gave the right answer. Then we wrote five phase plans that forgot to mention it.
+
+Built a V2 API with AI assistance. Fifteen sessions, twelve commits, 2,500 lines of plans. The mechanical throughput was exceptional. Every endpoint was clean, tested, well-structured — and returning nulls across the board.
+
+The public API calls the entity a "role." Internally, it's a "group" — different name, different service, different data layer. I knew this. The AI asked about it. We discussed it in chat. But across five increasingly detailed plans, not one contained the sentence: "A role IS a group — use the groups service." Ten seconds to write. Sixty percent of the project saved.
+
+Eric Evans formalized this in Domain-Driven Design (2003): teams need a deliberate process to surface AND record knowledge that feels obvious to whoever holds it. He called it Ubiquitous Language. Twenty-three years later, the lesson applies to AI-assisted work more than ever.
+
+More detail is not better than the right detail.
+
+Full post: https://tankthinks.net/2026/03/more-wonder-and-woe-with-ai/
+
+</div>

--- a/home/src/posts/2026/03/more-wonder-and-woe-with-ai.md
+++ b/home/src/posts/2026/03/more-wonder-and-woe-with-ai.md
@@ -81,20 +81,4 @@ Eric Evans, _Domain-Driven Design: Tackling Complexity in the Heart of Software_
 
 Dr. John, "Right Place Wrong Time" (1973). A song about timing, miscommunication, and having all the right ingredients in all the wrong arrangements. Also a perfect description of a five-phase project plan.
 
----
-
-## LinkedIn
-
-The AI asked the right question during planning. I gave the right answer. Then we wrote five phase plans that forgot to mention it.
-
-Built a V2 API with AI assistance. Fifteen sessions, twelve commits, 2,500 lines of plans. The mechanical throughput was exceptional. Every endpoint was clean, tested, well-structured — and returning nulls across the board.
-
-The public API calls the entity a "role." Internally, it's a "group" — different name, different service, different data layer. I knew this. The AI asked about it. We discussed it in chat. But across five increasingly detailed plans, not one contained the sentence: "A role IS a group — use the groups service." Ten seconds to write. Sixty percent of the project saved.
-
-Eric Evans formalized this in Domain-Driven Design (2003): teams need a deliberate process to surface AND record knowledge that feels obvious to whoever holds it. He called it Ubiquitous Language. Twenty-three years later, the lesson applies to AI-assisted work more than ever.
-
-More detail is not better than the right detail.
-
-Full post: https://tankthinks.net/2026/03/more-wonder-and-woe-with-ai/
-
 </div>

--- a/home/src/posts/2026/03/more-wonder-and-woe-with-ai.md
+++ b/home/src/posts/2026/03/more-wonder-and-woe-with-ai.md
@@ -24,9 +24,9 @@ Build a V2 public API exposing an existing capability. The V1 had been serving c
 
 ## The Wonder
 
-The AI execution loop worked exactly as advertised. Phase A was dependency upgrades: bumping the runtime and internal libraries. I wrote a plan, handed it over, the AI executed — updating configs, fixing breaking changes, running tests, committing. Phase B was the initial API: five endpoints, unit tests, smoke tests against staging. Clean code, logical commits, good conventions. Across the whole project: roughly fifteen sessions, a hundred human messages, twelve commits, and five phase plans totaling about 2,500 lines. The mechanical throughput was exceptional.
+I started with a solid PRD: the domain mapping, the endpoints, the conventions, the service dependencies. Then I did what felt responsible — I broke it into phases. Phase A: dependency upgrades. Phase B: initial API. Each phase got its own detailed plan. The AI executed each one beautifully: clean code, logical commits, passing tests. Fifteen sessions, a hundred human messages, five phase plans totaling about 2,500 lines. It _felt_ like going very fast.
 
-When the plan was clear, the AI was phenomenal.
+That feeling is the wonder — and the trap. Each phase plan was a translation of the original PRD into implementation steps, and each translation got more specific about _how_ while getting quieter about _why_. The PRD said "a role is a group — use the groups service." Phase B's plan said "implement CRUD endpoints for roles" and listed eighteen steps for doing it. The domain mapping didn't survive the decomposition. Not because anyone deleted it — because phasing _selects for_ implementation detail and _selects against_ the kind of foundational context that doesn't look like a task.
 
 ## The Woe
 

--- a/home/src/posts/2026/03/more-wonder-and-woe-with-ai.md
+++ b/home/src/posts/2026/03/more-wonder-and-woe-with-ai.md
@@ -1,9 +1,9 @@
 ---
 templateEngineOverride: njk,md
 metaTitle: More Wonder and Woe with AI
-metaDescription: An AI-assisted API build took 5 phases instead of 3. The root cause wasn't the AI — it was skipping the domain model mapping that Eric Evans told us about in 2003.
+metaDescription: An AI-assisted API build took 5 phases instead of 3 because domain knowledge stayed in one person's head. Eric Evans told us why in 2003.
 title: More Wonder and Woe with AI
-description: An AI-assisted API build took 5 phases instead of 3. The root cause wasn't the AI — it was skipping the domain model mapping that Eric Evans told us about in 2003.
+description: An AI-assisted API build took 5 phases instead of 3 because domain knowledge stayed in one person's head. Eric Evans told us why in 2003.
 featuredImg:
 subHeading: What Happens When You Skip the Map
 tags: ['ai', 'founding-engineer', 'devaiops', 'first-principles']
@@ -16,119 +16,73 @@ published: true
 
 # More Wonder and Woe with AI
 
-Last week I wrote about [joy and regret in a day of vibe coding](/2026/02/vibe-coding-joy-and-regret/). That was a single-day story: fast execution, scope creep, a 30-second question that saved an hour. Lesson learned, move on.
-
-This week I have a different story. Same tool, same operator, but a different failure mode. This time the problem wasn't scope creep — it was building on the wrong abstraction from the start. And this time, it took two days and five phases of work before I figured out what had gone wrong.
+Last week I wrote about [joy and regret in a day of vibe coding](/2026/02/vibe-coding-joy-and-regret/). That was a scope creep story — fast execution, rubber-stamped expansion, 25% of a day lost. This week's failure mode is different and, I think, more important: building confidently in the wrong direction because the plan never captured what mattered most.
 
 ## The Task
 
-The work was building a new public API — a V2 version of an existing capability. The V1 API had been serving customers for years through a web application, but now external consumers needed direct programmatic access. Five CRUD endpoints, proper pagination, an OpenAPI spec, infrastructure routing, the works.
-
-This is textbook AI-assisted work. Clear patterns, well-understood conventions, an existing reference implementation to follow. Exactly the kind of project where the AI execution loop shines.
+Build a V2 public API exposing an existing capability. The V1 had been serving customers for years through a web app; now external consumers needed direct programmatic access. Five CRUD endpoints, pagination, an OpenAPI spec, infrastructure routing. Textbook AI-assisted work — clear patterns, a reference implementation to follow.
 
 ## The Wonder
 
-And it did shine — for the parts that were well-specified.
+The AI execution loop worked exactly as advertised. Phase A was dependency upgrades: bumping the runtime and internal libraries. I wrote a plan, handed it over, the AI executed — updating configs, fixing breaking changes, running tests, committing. Phase B was the initial API: five endpoints, unit tests, smoke tests against staging. Clean code, logical commits, good conventions. Across the whole project: roughly fifteen sessions, a hundred human messages, twelve commits, and five phase plans totaling about 2,500 lines. The mechanical throughput was exceptional.
 
-The first phase was a set of dependency upgrades: bumping the language runtime, upgrading internal libraries to versions that supported the new API framework. The AI executed this cleanly. I wrote a plan, handed it over, and it worked through the steps — updating configs, fixing breaking changes, running tests, committing. Mechanical work, done mechanically. Beautiful.
-
-The second phase was the initial API implementation: five endpoints, unit tests, smoke tests against a staging environment. The AI produced clean code following existing conventions, wired up the test infrastructure, and committed in logical chunks. Twelve commits across the project, each with proper conventional commit messages. The commit discipline was better than most human engineers I've worked with.
-
-Here's the interaction profile across the whole project:
-
-| | |
-|---|---|
-| **AI sessions** | ~15-18 |
-| **Human messages** | ~80-120 across all sessions |
-| **Human time** | ~6-10 hours of active work over 2 days |
-| **Commits** | 12 |
-| **Phase plans written** | 5 detailed plans (~2,500 lines total) |
-
-The execution loop — write a detailed plan, hand it to the AI, let it execute step by step — is genuinely efficient for well-specified work. The plans for the dependency upgrade and the initial implementation executed cleanly. The AI absorbed the mechanical toil so I could think about architecture, just like in the [vibe coding session](/2026/02/vibe-coding-joy-and-regret/).
+When the plan was clear, the AI was phenomenal.
 
 ## The Woe
 
-Then I started UAT.
+Then I started UAT and sent a few curl requests. Every metadata field came back null. Names, descriptions, audit timestamps — all empty. Data access filters? Missing entirely. Structurally correct responses, full of nothing. The response shapes didn't follow our documented API conventions either — no wrapping object, no pagination, no filtering. These are standard requirements for any API we ship, but they weren't in the plan, so they weren't built.
 
-I deployed the API, sent a few curl requests, and immediately saw the problem: every metadata field was null. Names, descriptions, audit timestamps — all empty. The data access filters that should have controlled what each API key could see? Missing entirely. The API returned structurally correct responses full of nothing.
+That kicked off Phase D: eighteen steps fixing five issues that should have been specified from the start. But Phase D only treated symptoms.
 
-Worse, the response shapes didn't follow our documented conventions. No wrapping object. No pagination. No sorting or filtering. These aren't exotic requirements — they're standard for any API we ship. But they hadn't been specified in the plan, so they hadn't been built.
+Phase E revealed the disease. The V2 API had been built on the wrong service entirely.
 
-That kicked off Phase D: eighteen steps fixing five distinct issues. Response wrapping. Pagination. Metadata fields. A permissions endpoint. Standard stuff that should have been in the original implementation.
+In our system, what the public API calls a "role" is what the internal system calls a "group." Same entity, different names, different services. The V1 app had been using the groups service for years — it knew where the metadata lived, how to resolve access filters, how to traverse entity relationships. Two-plus years of battle-tested business logic.
 
-But Phase D only treated the symptoms. Phase E revealed the disease.
-
-## The Root Cause
-
-The V2 API had been built on top of the wrong data layer.
-
-In our system, what the public API calls a "role" is actually what the internal system calls a "group." Same entity, different names, different services managing them. The V1 web application had been using the groups service for years — it knew where the metadata lived, how to resolve data access filters, how to traverse the entity relationships. Two-plus years of business logic, battle-tested.
-
-Phase B built the V2 API by going directly to the roles data layer — a lower-level abstraction that only touches one database table. It was the obvious choice if you looked at the name ("roles API → roles service"), but it was wrong. All the metadata lived on the group entity. All the data access logic lived in the groups service. We had bypassed the business logic and gone straight to the raw data, then wondered why the responses were empty.
-
-Phase E was a rewrite. Not a bug fix — a fundamental change in which service the API called. If I had spent thirty minutes before Phase B answering one question — "what is a V2 role, and what existing entity does it map to?" — Phases D and E would not have existed.
+Phase B built the V2 API by going directly to the roles data layer — a lower-level abstraction that touches one database table. It was the obvious choice _if you looked at the name_ ("roles API → roles service"). But the metadata lived on group entities. The access logic lived in the groups service. We'd bypassed all of it and gone straight to raw data, then wondered why the responses were empty.
 
 <figure class="mb-10">
-  <img loading="lazy" src="https://frinkiac.com/img/S05E15/1052951.jpg" alt="Homer Simpson in the space shuttle, having caused a crisis by not understanding how things work" width="720" height="540">
+  <img loading="lazy" src="https://frinkiac.com/img/S05E15/1052951.jpg" alt="Homer Simpson in the space shuttle, realizing he's made a grave mistake" width="720" height="540">
   <figcaption class="text-center text-sm mt-3 text-gray-600 dark:text-gray-200">Me, realizing the API was built on the wrong abstraction for two days</figcaption>
 </figure>
 
-## What Eric Evans Told Us in 2003
+Phase E was a rewrite — not a bug fix. Five phases when there should have been three.
 
-This isn't a new failure mode. Eric Evans described it precisely in _Domain-Driven Design_ twenty-three years ago.[^1]
+## Write Things Down
 
-Evans' central argument is that software projects fail not because of technical complexity, but because of **domain complexity** — the gap between what the code models and what the business actually does. His prescription is the _Ubiquitous Language_: a shared vocabulary between developers and domain experts that keeps the code aligned with reality.
+Here's the thing: I _knew_ that a role was a group. That knowledge was in my head the entire time. I just never wrote it down. It never made it into the plan. And what's not in the plan doesn't exist — not for the AI, and frankly, not for any collaborator.
 
-Our project violated this in the most basic way possible. The public API used the word "role." The internal system used the word "group." They meant the same thing, but nobody stopped to say that out loud. So the AI built a "roles" service, and I reviewed and approved a "roles" service, and we were both wrong.
+This is [Principle #1](/2023/07/first-principles-1-write-things-down/) on this blog for a reason. You won't remember tomorrow. And your collaborator — human or AI — can't read your mind today. The information asymmetry is the killer. Things that are obvious to the person who's lived in the codebase for two years are completely invisible to the agent picking up the plan for the first time. Writing "a V2 role IS a V1 group — use the groups service" would have taken ten seconds. It would have saved sixty percent of the project.
 
-Evans would have caught it. His first move on any project is to map the domain — draw the entities, name the relationships, align the vocabulary. Not write code. Not design APIs. _Understand the domain._ It's the same instinct behind my own [first principle about domain understanding](/2023/08/first-principles-3-domain/): the best code clearly represents domain rules, and you can't represent rules you haven't articulated.
+Eric Evans formalized this in _Domain-Driven Design_ twenty-three years ago.[^1] His central insight isn't just "understand the domain" — it's that teams need a deliberate _process_ to surface knowledge that's trapped in individual heads. He called it _Ubiquitous Language_: a shared vocabulary, written down and enforced, that aligns code with reality. The reason you need a process is precisely because domain knowledge feels obvious to whoever holds it. "Role means group" felt so self-evident to me that I never thought to say it. Evans' whole methodology exists because that instinct — _surely everyone knows this_ — is reliably wrong.
 
-The AI can't do this step for you. It will happily build a beautifully clean implementation on top of the wrong abstraction. It doesn't know that "role" and "group" are the same thing unless you tell it. The AI optimizes for the plan you give it. If the plan is wrong, it builds the wrong thing faster than any human could.
+The AI makes this failure mode sharper. A human collaborator might have asked "hey, should we use the groups service?" The AI won't. It optimizes for the plan you give it. A clear, concise, _complete_ plan produces excellent work. A plan missing one key insight produces confident, clean, well-tested code built on the wrong foundation.
 
-This is the same lesson from last week's post, but at a different altitude. Last week, scope creep cost 25% of a single day. This week, a missing domain mapping cost 60% of a two-day project. Same root cause: the human didn't do the thinking that only the human can do.
+## One Plan, Not Five
 
-## What I'll Do Differently
+The other lesson is structural. Five phases, five plans, five deploy-test-discover cycles. Each phase existed because the previous one was incomplete. If I had written one comprehensive plan — dependencies, domain mapping, API contract, implementation on the correct service, infrastructure, docs — the project compresses to three phases at most. One upfront plan that captures the full picture beats five iterative plans that each discover what the last one missed. The iteration _felt_ productive. Each phase had clean execution. But the aggregate cost of building, deploying, discovering, replanning, and rebuilding dwarfed what a single morning of thorough planning would have cost.
 
-**Before writing code, write the domain model.** Thirty minutes with a whiteboard (or a markdown file) answering: What entities exist? What are they called in each system? What maps to what? This isn't optional preparation — it's the prerequisite that determines whether everything downstream is building on rock or sand.
-
-**Write the API contract first, not the implementation.** If I had drafted an OpenAPI spec with response shapes, pagination structure, and field lists before handing the AI a plan, every issue from Phase D would have been caught at design time. Design-first, not code-first.
-
-**Stop building new APIs by going directly to the data layer.** A V2 API should be a thin conformance layer over existing service functions, not a parallel implementation. Two years of business logic already existed. Bypassing it to "keep things simple" created the most complex outcome possible.
-
-**Treat infrastructure and documentation as part of "done."** Routing, OpenAPI specs, and docs aren't Phase C afterthoughts — they're part of the feature. If it's not routable and not documented, it's not shipped.
-
-**Keep the AI execution loop — but feed it better plans.** The write-a-plan-then-execute pattern is genuinely efficient. The problem wasn't the loop. It was plan _quality_. The dependency upgrade plan was excellent and executed flawlessly. The API implementation plan was missing the most important line: "a role IS a group."
-
-## The Theoretical Minimum
-
-The project could have been three phases instead of five:
-
-1. **Dependencies** — unavoidable prerequisite
-2. **API implementation** — built on the groups service from day one, with proper response shapes, pagination, and docs included
-3. **Final polish** — whatever genuinely novel issues emerge from UAT
-
-Instead, I got five phases because I skipped the thirty-minute domain mapping that would have told me which service to build on. The AI didn't skip it — I did. The AI doesn't know what it doesn't know. That's my job.
+The pattern is the same one I keep writing about: **powerful tools require disciplined operators**. The AI's execution was never the problem. My preparation was.
 
 # tl;dr
 
-Built a V2 public API with AI over two days. It took five phases when it should have taken three, because I didn't map the domain model before writing code. The API used the word "role" — but in our system, a role is a "group," managed by a completely different service. We built on the wrong abstraction, got empty responses, and had to rewrite. Eric Evans described this exact failure mode in _Domain-Driven Design_ in 2003: if the code's vocabulary doesn't match the domain's vocabulary, the code is wrong. AI makes this worse, not better — it builds the wrong thing faster and with more confidence. The fix is the oldest trick in software: understand the domain before you write a line of code.
+Built a V2 API with AI over two days. Took five phases instead of three because domain knowledge — "a role IS a group" — stayed in my head and never made it into the plan. The AI built clean, well-tested code on the wrong abstraction. Eric Evans described this in _Domain-Driven Design_ (2003): teams need a deliberate process to surface knowledge that feels obvious to whoever holds it but is invisible to everyone else. Write things down. One clear upfront plan beats five confident steps in the wrong direction.
 
 # Notes
 
 #### 1
 
-Eric Evans, _Domain-Driven Design: Tackling Complexity in the Heart of Software_ (2003). The book that coined "Ubiquitous Language" and "Bounded Context." If your team has ever argued about what a word means in your system, you need this book. It's twenty-three years old and more relevant than ever. Lindy approves.
+Eric Evans, _Domain-Driven Design: Tackling Complexity in the Heart of Software_ (2003). The book that coined "Ubiquitous Language" and "Bounded Context." His core methodology is a _process_ for extracting domain knowledge from the people who have it and encoding it where the whole team — or your AI agent — can use it. Twenty-three years old and more relevant than ever. Lindy approves.
 
 ---
 
 ## LinkedIn
 
-Built a V2 API with AI assistance over two days. Should have been a three-phase project — dependency upgrade, implementation, polish. Instead it was five phases, because I skipped the most important step: mapping the domain model before writing code.
+Built a V2 API with AI over two days. Should have been three phases — instead it was five, because critical domain knowledge stayed in my head and never made it into the plan.
 
-The API called the entity a "role." Our internal system called it a "group." Same thing, different name, different service. The AI built a clean implementation on the wrong abstraction. Every metadata field came back null.
+The API called the entity a "role." Internally, a role is a "group" — different name, different service, different data layer. The AI built clean code on the wrong abstraction. Every metadata field came back null.
 
-Eric Evans described this failure mode in Domain-Driven Design in 2003. AI makes it worse — it builds the wrong thing faster than any human could. The fix is still the oldest trick in software: understand the domain first.
+Eric Evans called this in Domain-Driven Design (2003): what's obvious to one person is invisible to everyone else. You need a process to surface it. Write things down. One clear upfront plan beats five confident steps in the wrong direction.
 
-Full write-up: https://tankthinks.net/2026/03/more-wonder-and-woe-with-ai/
+Full post: https://tankthinks.net/2026/03/more-wonder-and-woe-with-ai/
 
 </div>

--- a/home/src/posts/2026/03/more-wonder-and-woe-with-ai.md
+++ b/home/src/posts/2026/03/more-wonder-and-woe-with-ai.md
@@ -49,25 +49,27 @@ Phase E was a rewrite — not a bug fix. Five phases when there should have been
 
 ## Write Things Down
 
-Here's the thing: I _knew_ that a role was a group. It wasn't trapped in my head, either — the AI actually asked me about it during planning. We discussed it in chat. But somehow, that conversation never made it into the implementation plan. The insight survived the discussion and died in the document.
+Here's the thing: I _knew_ that a role was a group. It wasn't trapped in my head, either — the AI actually asked me about it during planning. We discussed it in chat. The right knowledge was surfaced at the right time.
 
-That's the lossy step. Not brain-to-conversation — conversation-to-plan. We talked about the right abstraction, and then the plan said "build a roles service" and neither of us caught the gap. What's not in the plan doesn't exist — not for the AI picking it up in a new session, and frankly, not for any collaborator picking it up on a Monday morning.
+Then it disappeared. Not because nobody said it — because we buried it under five increasingly detailed phase plans totaling 2,500 lines of implementation steps. The insight was _in_ the conversation. It just didn't survive the iterative process of writing more detailed plans. Each new phase document was thorough about _how_ to build things and silent about _which things to build on_. As Dr. John put it: "I'd have said the right thing, but I must have used the wrong line."[^2]
 
-This is [Principle #1](/2023/07/first-principles-1-write-things-down/) on this blog for a reason. The goal isn't to tell the AI how to write every line. It's to make sure the _important_ stuff — the domain mappings, the architectural decisions, the one sentence that changes which service you build on — is written down where it can't be lost. "A V2 role IS a V1 group — use the groups service." Ten seconds to write. Sixty percent of the project saved.
+That's the failure mode. Not a lack of knowledge — a lack of the _right_ detail in the _right_ place. More detail is not better than the right detail. 2,500 lines of plans, and not one of them contained the sentence: "A V2 role IS a V1 group — use the groups service." Ten seconds to write. Sixty percent of the project saved.
 
-Eric Evans formalized this in _Domain-Driven Design_ twenty-three years ago.[^1] His central insight isn't just "understand the domain" — it's that teams need a deliberate _process_ to surface and _record_ knowledge that feels obvious to whoever holds it. He called it _Ubiquitous Language_: a shared vocabulary, written down and enforced, that aligns code with reality. Evans' whole methodology exists because the instinct — _surely everyone knows this_ — is reliably wrong. We proved it. The AI asked. I answered. And we both moved on without writing it down.
+This is [Principle #1](/2023/07/first-principles-1-write-things-down/) on this blog for a reason. The goal isn't to tell the AI how to write every line. It's to make sure the important stuff — the domain mappings, the architectural decisions, the one sentence that changes which service you build on — makes it from conversation into the plan and _stays_ there through every revision.
+
+Eric Evans formalized this in _Domain-Driven Design_ twenty-three years ago.[^1] His central insight isn't just "understand the domain" — it's that teams need a deliberate _process_ to surface and _record_ knowledge that feels obvious to whoever holds it. He called it _Ubiquitous Language_: a shared vocabulary, written down and enforced, that aligns code with reality. Evans' whole methodology exists because the instinct — _surely everyone knows this_ — is reliably wrong. We proved it. The AI asked. I answered. And then we wrote five plans that forgot to mention it.
 
 The AI makes this failure mode sharper. It optimizes for the plan you give it. A clear, concise, _complete_ plan produces excellent work. A plan missing one key insight produces confident, clean, well-tested code built on the wrong foundation. Don't micromanage the implementation. But make damn sure the plan captures what matters.
 
-## One Plan, Not Five
+## The Right Detail, Not More Detail
 
-The other lesson is structural. Five phases, five plans, five deploy-test-discover cycles. Each phase existed because the previous one was incomplete. If I had written one comprehensive plan — dependencies, domain mapping, API contract, implementation on the correct service, infrastructure, docs — the project compresses to three phases at most. One upfront plan that captures the full picture beats five iterative plans that each discover what the last one missed. The iteration _felt_ productive. Each phase had clean execution. But the aggregate cost of building, deploying, discovering, replanning, and rebuilding dwarfed what a single morning of thorough planning would have cost.
+Five phases. Five plans. Five deploy-test-discover cycles. Each phase existed because the previous one was incomplete — not because it lacked detail, but because it lacked the _right_ detail. If I had written one comprehensive plan with the domain mapping front and center — dependencies, "role = group," API contract, implementation on the correct service, infrastructure, docs — the project compresses to three phases at most. One upfront plan with the right ten words beats five detailed plans that each discover what the last one missed.
 
 The pattern is the same one I keep writing about: **powerful tools require disciplined operators**. The AI's execution was never the problem. My preparation was.
 
 # tl;dr
 
-Built a V2 API with AI over two days. Took five phases instead of three because a critical domain insight — "a role IS a group" — was discussed in chat but never written into the plan. The AI asked the right question. I gave the right answer. Neither of us wrote it down. Eric Evans described this in _Domain-Driven Design_ (2003): teams need a deliberate process to surface _and record_ knowledge that feels obvious to whoever holds it. Don't tell the AI how to write every line. Make sure the plan captures what matters.
+Built a V2 API with AI over two days. Took five phases instead of three because a critical domain insight — "a role IS a group" — was discussed in chat but got lost across 2,500 lines of increasingly detailed phase plans. The AI asked the right question. I gave the right answer. Then we wrote five plans that forgot to mention it. More detail is not better than the right detail. Eric Evans described this in _Domain-Driven Design_ (2003): teams need a deliberate process to surface _and record_ knowledge that feels obvious to whoever holds it. Make sure the plan captures what matters.
 
 # Notes
 
@@ -75,15 +77,19 @@ Built a V2 API with AI over two days. Took five phases instead of three because 
 
 Eric Evans, _Domain-Driven Design: Tackling Complexity in the Heart of Software_ (2003). The book that coined "Ubiquitous Language" and "Bounded Context." His core methodology is a _process_ for extracting domain knowledge from the people who have it and encoding it where the whole team — or your AI agent — can use it. Twenty-three years old and more relevant than ever. Lindy approves.
 
+#### 2
+
+Dr. John, "Right Place Wrong Time" (1973). A song about timing, miscommunication, and having all the right ingredients in all the wrong arrangements. Also a perfect description of a five-phase project plan.
+
 ---
 
 ## LinkedIn
 
-Built a V2 API with AI over two days. Should have been three phases — it was five. The AI asked the right domain question during planning. I gave the right answer. Neither of us wrote it down in the plan.
+Built a V2 API with AI over two days. Should have been three phases — it was five. The AI asked the right domain question during planning. I gave the right answer. Then we buried it under 2,500 lines of detailed phase plans.
 
-The API called the entity a "role." Internally it was a "group." We discussed this — then the plan said "build a roles service" and nobody caught the gap. Clean code, wrong abstraction, null responses.
+The API called the entity a "role." Internally it was a "group." We discussed this — then the plans said "build a roles service" and nobody caught the gap. Clean code, wrong abstraction, null responses. More detail is not better than the right detail.
 
-Eric Evans described this in Domain-Driven Design (2003): teams need a process to surface AND record knowledge that feels obvious. Don't micromanage the AI. Make sure the plan captures what matters.
+Eric Evans described this in Domain-Driven Design (2003): teams need a process to surface AND record knowledge that feels obvious. Make sure the plan captures what matters.
 
 Full post: https://tankthinks.net/2026/03/more-wonder-and-woe-with-ai/
 

--- a/home/src/posts/2026/03/more-wonder-and-woe-with-ai.md
+++ b/home/src/posts/2026/03/more-wonder-and-woe-with-ai.md
@@ -42,7 +42,7 @@ Phase B built the V2 API by going directly to the roles data layer — a lower-l
 
 <figure class="mb-10">
   <img loading="lazy" src="https://frinkiac.com/img/S05E15/1052951.jpg" alt="Homer Simpson in the space shuttle, realizing he's made a grave mistake" width="720" height="540">
-  <figcaption class="text-center text-sm mt-3 text-gray-600 dark:text-gray-200">Me, realizing the API was built on the wrong abstraction for two days</figcaption>
+  <figcaption class="text-center text-sm mt-3 text-gray-600 dark:text-gray-200">Me, realizing the API was built on the wrong abstraction while preparing to welcome our AI overlords.</figcaption>
 </figure>
 
 Phase E was a rewrite — not a bug fix. Five phases when there should have been three.

--- a/home/src/posts/2026/03/more-wonder-and-woe-with-ai.md
+++ b/home/src/posts/2026/03/more-wonder-and-woe-with-ai.md
@@ -1,11 +1,11 @@
 ---
 templateEngineOverride: njk,md
-metaTitle: More Wonder and Woe with AI
-metaDescription: An AI-assisted API build took 5 phases instead of 3 because domain knowledge stayed in one person's head. Eric Evans told us why in 2003.
-title: More Wonder and Woe with AI
-description: An AI-assisted API build took 5 phases instead of 3 because domain knowledge stayed in one person's head. Eric Evans told us why in 2003.
+metaTitle: The Right Detail, Not More Detail
+metaDescription: AI artifacts generated from AI artifacts lose signal fast. One clear document and lots of validation beats five detailed plans that each discover what the last one missed.
+title: The Right Detail, Not More Detail
+description: AI artifacts generated from AI artifacts lose signal fast. One clear document and lots of validation beats five detailed plans that each discover what the last one missed.
 featuredImg:
-subHeading: What Happens When You Skip the Map
+subHeading: What AI-Assisted Development Taught Me About Signal and Noise
 tags: ['ai', 'founding-engineer', 'devaiops', 'first-principles']
 date: 2026-03-02
 updated:
@@ -14,71 +14,81 @@ published: true
 
 <div class="col-start-3 col-end-9">
 
-# More Wonder and Woe with AI
+# The Right Detail, Not More Detail
 
-Last week I wrote about [joy and regret in a day of vibe coding](/2026/02/vibe-coding-joy-and-regret/). That was a scope creep story — fast execution, rubber-stamped expansion, 25% of a day lost. This week's failure mode is different and, I think, more important: building confidently in the wrong direction because the plan never captured what mattered most.
+Last week I wrote about [joy and regret in a day of vibe coding](/2026/02/vibe-coding-joy-and-regret/). That was a scope creep story. This one is about something quieter and more dangerous: signal decay.
 
 ## The Task
 
-Build a V2 public API exposing an existing capability. The V1 had been serving customers for years through a web app; now external consumers needed direct programmatic access. Five CRUD endpoints, pagination, an OpenAPI spec, infrastructure routing. Textbook AI-assisted work — clear patterns, a reference implementation to follow.
+Build a V2 public API exposing an existing capability. The V1 had been serving customers for years through a web app; now external consumers needed direct programmatic access. Five CRUD endpoints, pagination, an OpenAPI spec, infrastructure routing. Textbook AI-assisted work.
 
-## The Wonder
+## What Happened
 
-I started with a solid PRD: the domain mapping, the endpoints, the conventions, the service dependencies. Then I did what felt responsible — I broke it into phases. Phase A: dependency upgrades. Phase B: initial API. Each phase got its own detailed plan. The AI executed each one beautifully: clean code, logical commits, passing tests. Fifteen sessions, a hundred human messages, five phase plans totaling about 2,500 lines. It _felt_ like going very fast.
+I wrote a PRD. It was solid — domain mapping, endpoints, conventions, service dependencies. Then I handed it to an AI agent and asked it to generate a detailed implementation plan. That plan was good, so I asked for a more detailed plan for the first phase. That plan was good, so I asked for a more detailed plan for the next phase. Five phases, five plans, 2,500 lines of implementation steps.
 
-That feeling is the wonder — and the trap. Each phase plan was a translation of the original PRD into implementation steps, and each translation got more specific about _how_ while getting quieter about _why_. The PRD said "a role is a group — use the groups service." Phase B's plan said "implement CRUD endpoints for roles" and listed eighteen steps for doing it. The domain mapping didn't survive the decomposition. Not because anyone deleted it — because phasing _selects for_ implementation detail and _selects against_ the kind of foundational context that doesn't look like a task.
+Each plan was generated from the one before it. Each was more detailed than the last. And each was a little further from the original document that actually mattered.
 
-## The Woe
+Here's the sentence that was in my PRD: **"A V2 role IS a V1 group — use the groups service."**
 
-Then I started UAT and sent a few curl requests. Every metadata field came back null. Names, descriptions, audit timestamps — all empty. Data access filters? Missing entirely. Structurally correct responses, full of nothing. The response shapes didn't follow our documented API conventions either — no wrapping object, no pagination, no filtering. These are standard requirements for any API we ship, but they weren't in the plan, so they weren't built.
+Here's what Phase B's plan said: "Implement CRUD endpoints for roles." Eighteen steps. Not one mentioned the groups service.
 
-That kicked off Phase D: eighteen steps fixing five issues that should have been specified from the start. But Phase D only treated symptoms.
+The AI built the V2 API by going directly to the roles data layer — a lower-level abstraction that touches one database table. It was the obvious choice _if you looked at the name_ ("roles API -> roles service"). But in our system, what the public API calls a "role" is what the internal system calls a "group." Same entity, different names, different services. The metadata lived on group entities. The access logic lived in the groups service. Two-plus years of battle-tested business logic, all bypassed.
 
-Phase E revealed the disease. The V2 API had been built on the wrong service entirely.
-
-In our system, what the public API calls a "role" is what the internal system calls a "group." Same entity, different names, different services. The V1 app had been using the groups service for years — it knew where the metadata lived, how to resolve access filters, how to traverse entity relationships. Two-plus years of battle-tested business logic.
-
-Phase B built the V2 API by going directly to the roles data layer — a lower-level abstraction that touches one database table. It was the obvious choice _if you looked at the name_ ("roles API → roles service"). But the metadata lived on group entities. The access logic lived in the groups service. We'd bypassed all of it and gone straight to raw data, then wondered why the responses were empty.
+I ran a few curl requests. Every metadata field came back null. Data access filters? Missing entirely. Structurally correct responses, full of nothing.
 
 <figure class="mb-10">
   <img loading="lazy" src="https://frinkiac.com/img/S05E15/1052951.jpg" alt="Homer Simpson in the space shuttle, realizing he's made a grave mistake" width="720" height="540">
-  <figcaption class="text-center text-sm mt-3 text-gray-600 dark:text-gray-200">Me, realizing the API was built on the wrong abstraction while preparing to welcome our AI overlords.</figcaption>
+  <figcaption class="text-center text-sm mt-3 text-gray-600 dark:text-gray-200">Me, realizing the API was built on the wrong abstraction.</figcaption>
 </figure>
 
-Phase E was a rewrite — not a bug fix. Five phases when there should have been three.
+Five phases when there should have been three. Not because the AI was bad — the code was clean, the tests passed, the commits were logical. Because the one sentence that mattered didn't survive the game of telephone I'd set up between my documents.
 
-## Write Things Down
+## Signal Decay
 
-Here's the thing: I _knew_ that a role was a group. It wasn't trapped in my head, either — the AI actually asked me about it during planning. We discussed it in chat. The right knowledge was surfaced at the right time.
+Here's the pattern: you write a document. You ask the AI to generate a more detailed document from it. You ask the AI to generate a more detailed document from _that_. Each generation is a lossy compression. Implementation detail goes up. Domain context goes down. By the third derivative, the AI is optimizing for the shape of the plan, not the shape of the problem.
 
-Then it disappeared. Not because nobody said it — because we buried it under five increasingly detailed phase plans totaling 2,500 lines of implementation steps. The insight was _in_ the conversation. It just didn't survive the iterative process of writing more detailed plans. Each new phase document was thorough about _how_ to build things and silent about _which things to build on_. As Dr. John put it: "I'd have said the right thing, but I must have used the wrong line."[^2]
+This is the same thing that happens when you photocopy a photocopy. Or when a meeting summary gets summarized into a status report that gets summarized into an executive briefing. Each step selects for what _looks_ like the right kind of detail and drops what doesn't fit the format. The critical insight — "a role is a group" — doesn't look like an implementation step, so it doesn't survive.
 
-That's the failure mode. Not a lack of knowledge — a lack of the _right_ detail in the _right_ place. More detail is not better than the right detail. 2,500 lines of plans, and not one of them contained the sentence: "A V2 role IS a V1 group — use the groups service." Ten seconds to write. Sixty percent of the project saved.
+As Dr. John put it: "I been in the right place, but it must have been the wrong time."[^2] The knowledge was surfaced at the right moment. The AI actually _asked me_ about the domain mapping during planning. I answered correctly. Then we generated five plans that forgot to mention it.
 
-This is [Principle #1](/2023/07/first-principles-1-write-things-down/) on this blog for a reason. The goal isn't to tell the AI how to write every line. It's to make sure the important stuff — the domain mappings, the architectural decisions, the one sentence that changes which service you build on — makes it from conversation into the plan and _stays_ there through every revision.
+Eric Evans described this problem twenty-three years ago in _Domain-Driven Design_.[^1] His central insight isn't "understand your domain" — any competent engineer does that. It's that teams need a deliberate process to surface and _record_ knowledge that feels obvious to whoever holds it. He called it _Ubiquitous Language_: a shared vocabulary, written down and enforced, that keeps code aligned with reality. Evans' whole methodology exists because the instinct — _surely everyone knows this_ — is reliably wrong. AI makes it worse, because the AI _did_ know it, briefly, in one conversation, before burying it under 2,500 lines of generated plans.
 
-Eric Evans formalized this in _Domain-Driven Design_ twenty-three years ago.[^1] His central insight isn't just "understand the domain" — it's that teams need a deliberate _process_ to surface and _record_ knowledge that feels obvious to whoever holds it. He called it _Ubiquitous Language_: a shared vocabulary, written down and enforced, that aligns code with reality. Evans' whole methodology exists because the instinct — _surely everyone knows this_ — is reliably wrong. We proved it. The AI asked. I answered. And then we wrote five plans that forgot to mention it.
+I've [written about this before](/2023/08/first-principles-4-domain/). _Make the important parts important._ The failure here wasn't that I didn't understand my domain. It was that I let the important parts get diluted across a stack of derivative documents until they weren't important anymore.
 
-The AI makes this failure mode sharper. It optimizes for the plan you give it. A clear, concise, _complete_ plan produces excellent work. A plan missing one key insight produces confident, clean, well-tested code built on the wrong foundation. Don't micromanage the implementation. But make damn sure the plan captures what matters.
+## One Document, Many Validators
 
-## The Right Detail, Not More Detail
+The fix isn't "write better plans." It's: **write one clear document and then spend the rest of your time validating it.**
 
-Five phases. Five plans. Five deploy-test-discover cycles. Each phase existed because the previous one was incomplete — not because it lacked detail, but because it lacked the _right_ detail. If I had written one comprehensive plan with the domain mapping front and center — dependencies, "role = group," API contract, implementation on the correct service, infrastructure, docs — the project compresses to three phases at most. One upfront plan with the right ten words beats five detailed plans that each discover what the last one missed.
+That one document is your domain map. Not a phase plan. Not a task list. A short, authoritative source of truth that says _what things are_, _what they're called_, and _which services own them_. The kind of document Evans would call a Ubiquitous Language spec. In my case, the ten words that would have saved 40% of the project: "A V2 role IS a V1 group — use the groups service."
 
-The pattern is the same one I keep writing about: **powerful tools require disciplined operators**. The AI's execution was never the problem. My preparation was.
+Then, instead of generating more plans from that document, point agents _at_ it as validators:
+
+- A **unit test agent** that writes tests against the domain map, not the implementation. "Does the roles endpoint call the groups service?"
+- A **conformance agent** that checks the implementation against your API conventions. "Does every response include the wrapping object, pagination, and filtering?"
+- A **UAT agent** that runs curl requests and verifies real responses against expected shapes. "Does the metadata come back populated?"
+
+Each of these agents is cheap. Each one catches a different class of drift. And critically, each one points _back_ at the source document rather than generating a new derivative of it. The document stays still. The validators orbit around it.
+
+This is the inversion that matters: don't use AI to generate more artifacts from your plan. Use AI to _validate_ the artifact you already have. More detail is not better than the right detail. One document and five validators beats five documents and zero validators every time.
+
+## The Pattern
+
+It's the same one I keep writing about: **powerful tools require disciplined operators**. The AI's execution was never the problem. The game of telephone I set up between my documents was.
+
+Write the domain map. Keep it short. Keep it authoritative. Then stop generating plans and start generating tests.
 
 # tl;dr
 
-Built a V2 API with AI over two days. Took five phases instead of three because a critical domain insight — "a role IS a group" — was discussed in chat but got lost across 2,500 lines of increasingly detailed phase plans. The AI asked the right question. I gave the right answer. Then we wrote five plans that forgot to mention it. More detail is not better than the right detail. Eric Evans described this in _Domain-Driven Design_ (2003): teams need a deliberate process to surface _and record_ knowledge that feels obvious to whoever holds it. Make sure the plan captures what matters.
+Built a V2 API with AI assistance. A critical domain insight — "a role IS a group" — was in my original PRD but got lost across five AI-generated plans, each more detailed and further from the source. The code was clean; it was just built on the wrong service. AI artifacts generated from AI artifacts lose signal fast. Eric Evans told us why in 2003: teams need a deliberate process to record knowledge that feels obvious. The fix: write one clear domain document and spend the rest of your time on validation agents — unit tests, conformance checks, UAT — that point back at the source instead of generating more derivatives from it.
 
 # Notes
 
 #### 1
 
-Eric Evans, _Domain-Driven Design: Tackling Complexity in the Heart of Software_ (2003). The book that coined "Ubiquitous Language" and "Bounded Context." His core methodology is a _process_ for extracting domain knowledge from the people who have it and encoding it where the whole team — or your AI agent — can use it. Twenty-three years old and more relevant than ever. Lindy approves.
+Eric Evans, _Domain-Driven Design: Tackling Complexity in the Heart of Software_ (2003). The book that coined "Ubiquitous Language" and "Bounded Context." His core methodology is a process for extracting domain knowledge from the people who have it and encoding it where the whole team — or your AI agent — can use it. Twenty-three years old and more relevant than ever. Lindy approves.
 
 #### 2
 
-Dr. John, "Right Place Wrong Time" (1973). A song about timing, miscommunication, and having all the right ingredients in all the wrong arrangements. Also a perfect description of a five-phase project plan.
+Dr. John, "Right Place Wrong Time" (1973). A song about timing, miscommunication, and having all the right ingredients in all the wrong arrangements. Also a perfect description of domain knowledge that gets surfaced in chat and buried in plans.
 
 </div>

--- a/home/src/posts/2026/03/more-wonder-and-woe-with-ai.md
+++ b/home/src/posts/2026/03/more-wonder-and-woe-with-ai.md
@@ -49,13 +49,15 @@ Phase E was a rewrite — not a bug fix. Five phases when there should have been
 
 ## Write Things Down
 
-Here's the thing: I _knew_ that a role was a group. That knowledge was in my head the entire time. I just never wrote it down. It never made it into the plan. And what's not in the plan doesn't exist — not for the AI, and frankly, not for any collaborator.
+Here's the thing: I _knew_ that a role was a group. It wasn't trapped in my head, either — the AI actually asked me about it during planning. We discussed it in chat. But somehow, that conversation never made it into the implementation plan. The insight survived the discussion and died in the document.
 
-This is [Principle #1](/2023/07/first-principles-1-write-things-down/) on this blog for a reason. You won't remember tomorrow. And your collaborator — human or AI — can't read your mind today. The information asymmetry is the killer. Things that are obvious to the person who's lived in the codebase for two years are completely invisible to the agent picking up the plan for the first time. Writing "a V2 role IS a V1 group — use the groups service" would have taken ten seconds. It would have saved sixty percent of the project.
+That's the lossy step. Not brain-to-conversation — conversation-to-plan. We talked about the right abstraction, and then the plan said "build a roles service" and neither of us caught the gap. What's not in the plan doesn't exist — not for the AI picking it up in a new session, and frankly, not for any collaborator picking it up on a Monday morning.
 
-Eric Evans formalized this in _Domain-Driven Design_ twenty-three years ago.[^1] His central insight isn't just "understand the domain" — it's that teams need a deliberate _process_ to surface knowledge that's trapped in individual heads. He called it _Ubiquitous Language_: a shared vocabulary, written down and enforced, that aligns code with reality. The reason you need a process is precisely because domain knowledge feels obvious to whoever holds it. "Role means group" felt so self-evident to me that I never thought to say it. Evans' whole methodology exists because that instinct — _surely everyone knows this_ — is reliably wrong.
+This is [Principle #1](/2023/07/first-principles-1-write-things-down/) on this blog for a reason. The goal isn't to tell the AI how to write every line. It's to make sure the _important_ stuff — the domain mappings, the architectural decisions, the one sentence that changes which service you build on — is written down where it can't be lost. "A V2 role IS a V1 group — use the groups service." Ten seconds to write. Sixty percent of the project saved.
 
-The AI makes this failure mode sharper. A human collaborator might have asked "hey, should we use the groups service?" The AI won't. It optimizes for the plan you give it. A clear, concise, _complete_ plan produces excellent work. A plan missing one key insight produces confident, clean, well-tested code built on the wrong foundation.
+Eric Evans formalized this in _Domain-Driven Design_ twenty-three years ago.[^1] His central insight isn't just "understand the domain" — it's that teams need a deliberate _process_ to surface and _record_ knowledge that feels obvious to whoever holds it. He called it _Ubiquitous Language_: a shared vocabulary, written down and enforced, that aligns code with reality. Evans' whole methodology exists because the instinct — _surely everyone knows this_ — is reliably wrong. We proved it. The AI asked. I answered. And we both moved on without writing it down.
+
+The AI makes this failure mode sharper. It optimizes for the plan you give it. A clear, concise, _complete_ plan produces excellent work. A plan missing one key insight produces confident, clean, well-tested code built on the wrong foundation. Don't micromanage the implementation. But make damn sure the plan captures what matters.
 
 ## One Plan, Not Five
 
@@ -65,7 +67,7 @@ The pattern is the same one I keep writing about: **powerful tools require disci
 
 # tl;dr
 
-Built a V2 API with AI over two days. Took five phases instead of three because domain knowledge — "a role IS a group" — stayed in my head and never made it into the plan. The AI built clean, well-tested code on the wrong abstraction. Eric Evans described this in _Domain-Driven Design_ (2003): teams need a deliberate process to surface knowledge that feels obvious to whoever holds it but is invisible to everyone else. Write things down. One clear upfront plan beats five confident steps in the wrong direction.
+Built a V2 API with AI over two days. Took five phases instead of three because a critical domain insight — "a role IS a group" — was discussed in chat but never written into the plan. The AI asked the right question. I gave the right answer. Neither of us wrote it down. Eric Evans described this in _Domain-Driven Design_ (2003): teams need a deliberate process to surface _and record_ knowledge that feels obvious to whoever holds it. Don't tell the AI how to write every line. Make sure the plan captures what matters.
 
 # Notes
 
@@ -77,11 +79,11 @@ Eric Evans, _Domain-Driven Design: Tackling Complexity in the Heart of Software_
 
 ## LinkedIn
 
-Built a V2 API with AI over two days. Should have been three phases — instead it was five, because critical domain knowledge stayed in my head and never made it into the plan.
+Built a V2 API with AI over two days. Should have been three phases — it was five. The AI asked the right domain question during planning. I gave the right answer. Neither of us wrote it down in the plan.
 
-The API called the entity a "role." Internally, a role is a "group" — different name, different service, different data layer. The AI built clean code on the wrong abstraction. Every metadata field came back null.
+The API called the entity a "role." Internally it was a "group." We discussed this — then the plan said "build a roles service" and nobody caught the gap. Clean code, wrong abstraction, null responses.
 
-Eric Evans called this in Domain-Driven Design (2003): what's obvious to one person is invisible to everyone else. You need a process to surface it. Write things down. One clear upfront plan beats five confident steps in the wrong direction.
+Eric Evans described this in Domain-Driven Design (2003): teams need a process to surface AND record knowledge that feels obvious. Don't micromanage the AI. Make sure the plan captures what matters.
 
 Full post: https://tankthinks.net/2026/03/more-wonder-and-woe-with-ai/
 

--- a/home/src/posts/2026/03/more-wonder-and-woe-with-ai.md
+++ b/home/src/posts/2026/03/more-wonder-and-woe-with-ai.md
@@ -81,16 +81,3 @@ Eric Evans, _Domain-Driven Design: Tackling Complexity in the Heart of Software_
 
 Dr. John, "Right Place Wrong Time" (1973). A song about timing, miscommunication, and having all the right ingredients in all the wrong arrangements. Also a perfect description of a five-phase project plan.
 
----
-
-## LinkedIn
-
-Built a V2 API with AI over two days. Should have been three phases — it was five. The AI asked the right domain question during planning. I gave the right answer. Then we buried it under 2,500 lines of detailed phase plans.
-
-The API called the entity a "role." Internally it was a "group." We discussed this — then the plans said "build a roles service" and nobody caught the gap. Clean code, wrong abstraction, null responses. More detail is not better than the right detail.
-
-Eric Evans described this in Domain-Driven Design (2003): teams need a process to surface AND record knowledge that feels obvious. Make sure the plan captures what matters.
-
-Full post: https://tankthinks.net/2026/03/more-wonder-and-woe-with-ai/
-
-</div>

--- a/home/src/posts/2026/03/more-wonder-and-woe-with-ai.md
+++ b/home/src/posts/2026/03/more-wonder-and-woe-with-ai.md
@@ -24,15 +24,12 @@ Build a V2 public API exposing an existing capability. The V1 had been serving c
 
 ## What Happened
 
-I wrote a PRD. It was solid — domain mapping, endpoints, conventions, service dependencies. Then I handed it to an AI agent and asked it to generate a detailed implementation plan. That plan was good, so I asked for a more detailed plan for the first phase. That plan was good, so I asked for a more detailed plan for the next phase. Five phases, five plans, 2,500 lines of implementation steps.
+AI an I wrote a PRD together. Claude asked good questions. The PRD was solid — domain mapping, endpoints, conventions, service dependencies. Then I handed it to an AI agent for implementation. The AI agent discovered that our implementation required a few major version dependency upgrades. OK ... let's do that in a Phase 1 iteration _before_ the actual implementation, right? Whoops. AI generated 3 phases of implementation from our PRD. Each one inconveniently "forgot" important details from the PRD, for example:
+  
+  - **"A V2 role IS a V1 group — use the groups service."**
+  - **"Follow the V2 API Convention with Paginiation, Filtering, and Sorting"**
 
-Each plan was generated from the one before it. Each was more detailed than the last. And each was a little further from the original document that actually mattered.
-
-Here's the sentence that was in my PRD: **"A V2 role IS a V1 group — use the groups service."**
-
-Here's what Phase B's plan said: "Implement CRUD endpoints for roles." Eighteen steps. Not one mentioned the groups service.
-
-The AI built the V2 API by going directly to the roles data layer — a lower-level abstraction that touches one database table. It was the obvious choice _if you looked at the name_ ("roles API -> roles service"). But in our system, what the public API calls a "role" is what the internal system calls a "group." Same entity, different names, different services. The metadata lived on group entities. The access logic lived in the groups service. Two-plus years of battle-tested business logic, all bypassed.
+Here's what Phase B's plan said: "Implement CRUD endpoints for roles." Eighteen steps. Not one mentioned the important invariants captured in the PRD!
 
 I ran a few curl requests. Every metadata field came back null. Data access filters? Missing entirely. Structurally correct responses, full of nothing.
 
@@ -41,15 +38,15 @@ I ran a few curl requests. Every metadata field came back null. Data access filt
   <figcaption class="text-center text-sm mt-3 text-gray-600 dark:text-gray-200">Me, realizing the API was built on the wrong abstraction.</figcaption>
 </figure>
 
-Five phases when there should have been three. Not because the AI was bad — the code was clean, the tests passed, the commits were logical. Because the one sentence that mattered didn't survive the game of telephone I'd set up between my documents.
+Then we did 3 more Phases of cleanup work bridging the gap from implementation back to PRD.
+
+Five phases when there should have been three. Why?
 
 ## Signal Decay
 
-Here's the pattern: you write a document. You ask the AI to generate a more detailed document from it. You ask the AI to generate a more detailed document from _that_. Each generation is a lossy compression. Implementation detail goes up. Domain context goes down. By the third derivative, the AI is optimizing for the shape of the plan, not the shape of the problem.
+Here's the pattern: you write a document. You ask the AI to generate a more detailed document from it. AI spits out 2500 lines of implementation plan that is just as difficult to review as the code itself. Spaghetti Monster help you if you need to generate _another_ document from one of these detailed plans! Each generation is a lossy compression. Implementation detail goes up. Domain context goes down. By the third derivative, the AI is optimizing for the shape of the plan, not the shape of the problem.
 
-This is the same thing that happens when you photocopy a photocopy. Or when a meeting summary gets summarized into a status report that gets summarized into an executive briefing. Each step selects for what _looks_ like the right kind of detail and drops what doesn't fit the format. The critical insight — "a role is a group" — doesn't look like an implementation step, so it doesn't survive.
-
-As Dr. John put it: "I been in the right place, but it must have been the wrong time."[^2] The knowledge was surfaced at the right moment. The AI actually _asked me_ about the domain mapping during planning. I answered correctly. Then we generated five plans that forgot to mention it.
+As Dr. John put it: "I'd have said the right thing, but I must have used the wrong line."[^2] The knowledge was there. The AI actually _asked me_ about the domain mapping during planning. I answered correctly. Then we generated detailed implementation plans that forgot to mention it.
 
 Eric Evans described this problem twenty-three years ago in _Domain-Driven Design_.[^1] His central insight isn't "understand your domain" — any competent engineer does that. It's that teams need a deliberate process to surface and _record_ knowledge that feels obvious to whoever holds it. He called it _Ubiquitous Language_: a shared vocabulary, written down and enforced, that keeps code aligned with reality. Evans' whole methodology exists because the instinct — _surely everyone knows this_ — is reliably wrong. AI makes it worse, because the AI _did_ know it, briefly, in one conversation, before burying it under 2,500 lines of generated plans.
 
@@ -79,7 +76,7 @@ Write the domain map. Keep it short. Keep it authoritative. Then stop generating
 
 # tl;dr
 
-Built a V2 API with AI assistance. A critical domain insight — "a role IS a group" — was in my original PRD but got lost across five AI-generated plans, each more detailed and further from the source. The code was clean; it was just built on the wrong service. AI artifacts generated from AI artifacts lose signal fast. Eric Evans told us why in 2003: teams need a deliberate process to record knowledge that feels obvious. The fix: write one clear domain document and spend the rest of your time on validation agents — unit tests, conformance checks, UAT — that point back at the source instead of generating more derivatives from it.
+Built a V2 API with AI assistance. A critical domain insight — "a role IS a group" — was in my original PRD but got lost across five AI-generated plans, each more detailed, further from the source, and harder to review. The code was clean; it was just built on the wrong service. AI artifacts generated from AI artifacts lose signal fast. Eric Evans told us why in 2003: teams need a deliberate process to record knowledge that feels obvious. The fix: write one clear domain document and spend the rest of your time on validation agents — unit tests, conformance checks, UAT — that point back at the source instead of generating more derivatives from it.
 
 # Notes
 

--- a/home/src/posts/2026/03/more-wonder-and-woe-with-ai.md
+++ b/home/src/posts/2026/03/more-wonder-and-woe-with-ai.md
@@ -1,0 +1,134 @@
+---
+templateEngineOverride: njk,md
+metaTitle: More Wonder and Woe with AI
+metaDescription: An AI-assisted API build took 5 phases instead of 3. The root cause wasn't the AI — it was skipping the domain model mapping that Eric Evans told us about in 2003.
+title: More Wonder and Woe with AI
+description: An AI-assisted API build took 5 phases instead of 3. The root cause wasn't the AI — it was skipping the domain model mapping that Eric Evans told us about in 2003.
+featuredImg:
+subHeading: What Happens When You Skip the Map
+tags: ['ai', 'founding-engineer', 'devaiops', 'first-principles']
+date: 2026-03-02
+updated:
+published: true
+---
+
+<div class="col-start-3 col-end-9">
+
+# More Wonder and Woe with AI
+
+Last week I wrote about [joy and regret in a day of vibe coding](/2026/02/vibe-coding-joy-and-regret/). That was a single-day story: fast execution, scope creep, a 30-second question that saved an hour. Lesson learned, move on.
+
+This week I have a different story. Same tool, same operator, but a different failure mode. This time the problem wasn't scope creep — it was building on the wrong abstraction from the start. And this time, it took two days and five phases of work before I figured out what had gone wrong.
+
+## The Task
+
+The work was building a new public API — a V2 version of an existing capability. The V1 API had been serving customers for years through a web application, but now external consumers needed direct programmatic access. Five CRUD endpoints, proper pagination, an OpenAPI spec, infrastructure routing, the works.
+
+This is textbook AI-assisted work. Clear patterns, well-understood conventions, an existing reference implementation to follow. Exactly the kind of project where the AI execution loop shines.
+
+## The Wonder
+
+And it did shine — for the parts that were well-specified.
+
+The first phase was a set of dependency upgrades: bumping the language runtime, upgrading internal libraries to versions that supported the new API framework. The AI executed this cleanly. I wrote a plan, handed it over, and it worked through the steps — updating configs, fixing breaking changes, running tests, committing. Mechanical work, done mechanically. Beautiful.
+
+The second phase was the initial API implementation: five endpoints, unit tests, smoke tests against a staging environment. The AI produced clean code following existing conventions, wired up the test infrastructure, and committed in logical chunks. Twelve commits across the project, each with proper conventional commit messages. The commit discipline was better than most human engineers I've worked with.
+
+Here's the interaction profile across the whole project:
+
+| | |
+|---|---|
+| **AI sessions** | ~15-18 |
+| **Human messages** | ~80-120 across all sessions |
+| **Human time** | ~6-10 hours of active work over 2 days |
+| **Commits** | 12 |
+| **Phase plans written** | 5 detailed plans (~2,500 lines total) |
+
+The execution loop — write a detailed plan, hand it to the AI, let it execute step by step — is genuinely efficient for well-specified work. The plans for the dependency upgrade and the initial implementation executed cleanly. The AI absorbed the mechanical toil so I could think about architecture, just like in the [vibe coding session](/2026/02/vibe-coding-joy-and-regret/).
+
+## The Woe
+
+Then I started UAT.
+
+I deployed the API, sent a few curl requests, and immediately saw the problem: every metadata field was null. Names, descriptions, audit timestamps — all empty. The data access filters that should have controlled what each API key could see? Missing entirely. The API returned structurally correct responses full of nothing.
+
+Worse, the response shapes didn't follow our documented conventions. No wrapping object. No pagination. No sorting or filtering. These aren't exotic requirements — they're standard for any API we ship. But they hadn't been specified in the plan, so they hadn't been built.
+
+That kicked off Phase D: eighteen steps fixing five distinct issues. Response wrapping. Pagination. Metadata fields. A permissions endpoint. Standard stuff that should have been in the original implementation.
+
+But Phase D only treated the symptoms. Phase E revealed the disease.
+
+## The Root Cause
+
+The V2 API had been built on top of the wrong data layer.
+
+In our system, what the public API calls a "role" is actually what the internal system calls a "group." Same entity, different names, different services managing them. The V1 web application had been using the groups service for years — it knew where the metadata lived, how to resolve data access filters, how to traverse the entity relationships. Two-plus years of business logic, battle-tested.
+
+Phase B built the V2 API by going directly to the roles data layer — a lower-level abstraction that only touches one database table. It was the obvious choice if you looked at the name ("roles API → roles service"), but it was wrong. All the metadata lived on the group entity. All the data access logic lived in the groups service. We had bypassed the business logic and gone straight to the raw data, then wondered why the responses were empty.
+
+Phase E was a rewrite. Not a bug fix — a fundamental change in which service the API called. If I had spent thirty minutes before Phase B answering one question — "what is a V2 role, and what existing entity does it map to?" — Phases D and E would not have existed.
+
+<figure class="mb-10">
+  <img loading="lazy" src="https://frinkiac.com/img/S05E15/1052951.jpg" alt="Homer Simpson in the space shuttle, having caused a crisis by not understanding how things work" width="720" height="540">
+  <figcaption class="text-center text-sm mt-3 text-gray-600 dark:text-gray-200">Me, realizing the API was built on the wrong abstraction for two days</figcaption>
+</figure>
+
+## What Eric Evans Told Us in 2003
+
+This isn't a new failure mode. Eric Evans described it precisely in _Domain-Driven Design_ twenty-three years ago.[^1]
+
+Evans' central argument is that software projects fail not because of technical complexity, but because of **domain complexity** — the gap between what the code models and what the business actually does. His prescription is the _Ubiquitous Language_: a shared vocabulary between developers and domain experts that keeps the code aligned with reality.
+
+Our project violated this in the most basic way possible. The public API used the word "role." The internal system used the word "group." They meant the same thing, but nobody stopped to say that out loud. So the AI built a "roles" service, and I reviewed and approved a "roles" service, and we were both wrong.
+
+Evans would have caught it. His first move on any project is to map the domain — draw the entities, name the relationships, align the vocabulary. Not write code. Not design APIs. _Understand the domain._ It's the same instinct behind my own [first principle about domain understanding](/2023/08/first-principles-3-domain/): the best code clearly represents domain rules, and you can't represent rules you haven't articulated.
+
+The AI can't do this step for you. It will happily build a beautifully clean implementation on top of the wrong abstraction. It doesn't know that "role" and "group" are the same thing unless you tell it. The AI optimizes for the plan you give it. If the plan is wrong, it builds the wrong thing faster than any human could.
+
+This is the same lesson from last week's post, but at a different altitude. Last week, scope creep cost 25% of a single day. This week, a missing domain mapping cost 60% of a two-day project. Same root cause: the human didn't do the thinking that only the human can do.
+
+## What I'll Do Differently
+
+**Before writing code, write the domain model.** Thirty minutes with a whiteboard (or a markdown file) answering: What entities exist? What are they called in each system? What maps to what? This isn't optional preparation — it's the prerequisite that determines whether everything downstream is building on rock or sand.
+
+**Write the API contract first, not the implementation.** If I had drafted an OpenAPI spec with response shapes, pagination structure, and field lists before handing the AI a plan, every issue from Phase D would have been caught at design time. Design-first, not code-first.
+
+**Stop building new APIs by going directly to the data layer.** A V2 API should be a thin conformance layer over existing service functions, not a parallel implementation. Two years of business logic already existed. Bypassing it to "keep things simple" created the most complex outcome possible.
+
+**Treat infrastructure and documentation as part of "done."** Routing, OpenAPI specs, and docs aren't Phase C afterthoughts — they're part of the feature. If it's not routable and not documented, it's not shipped.
+
+**Keep the AI execution loop — but feed it better plans.** The write-a-plan-then-execute pattern is genuinely efficient. The problem wasn't the loop. It was plan _quality_. The dependency upgrade plan was excellent and executed flawlessly. The API implementation plan was missing the most important line: "a role IS a group."
+
+## The Theoretical Minimum
+
+The project could have been three phases instead of five:
+
+1. **Dependencies** — unavoidable prerequisite
+2. **API implementation** — built on the groups service from day one, with proper response shapes, pagination, and docs included
+3. **Final polish** — whatever genuinely novel issues emerge from UAT
+
+Instead, I got five phases because I skipped the thirty-minute domain mapping that would have told me which service to build on. The AI didn't skip it — I did. The AI doesn't know what it doesn't know. That's my job.
+
+# tl;dr
+
+Built a V2 public API with AI over two days. It took five phases when it should have taken three, because I didn't map the domain model before writing code. The API used the word "role" — but in our system, a role is a "group," managed by a completely different service. We built on the wrong abstraction, got empty responses, and had to rewrite. Eric Evans described this exact failure mode in _Domain-Driven Design_ in 2003: if the code's vocabulary doesn't match the domain's vocabulary, the code is wrong. AI makes this worse, not better — it builds the wrong thing faster and with more confidence. The fix is the oldest trick in software: understand the domain before you write a line of code.
+
+# Notes
+
+#### 1
+
+Eric Evans, _Domain-Driven Design: Tackling Complexity in the Heart of Software_ (2003). The book that coined "Ubiquitous Language" and "Bounded Context." If your team has ever argued about what a word means in your system, you need this book. It's twenty-three years old and more relevant than ever. Lindy approves.
+
+---
+
+## LinkedIn
+
+Built a V2 API with AI assistance over two days. Should have been a three-phase project — dependency upgrade, implementation, polish. Instead it was five phases, because I skipped the most important step: mapping the domain model before writing code.
+
+The API called the entity a "role." Our internal system called it a "group." Same thing, different name, different service. The AI built a clean implementation on the wrong abstraction. Every metadata field came back null.
+
+Eric Evans described this failure mode in Domain-Driven Design in 2003. AI makes it worse — it builds the wrong thing faster than any human could. The fix is still the oldest trick in software: understand the domain first.
+
+Full write-up: https://tankthinks.net/2026/03/more-wonder-and-woe-with-ai/
+
+</div>


### PR DESCRIPTION
## Summary
Adds a new blog post exploring lessons learned from an AI-assisted API development project that required five phases instead of the planned three due to incomplete domain knowledge in the initial plan.

## Changes
- **New blog post**: `home/src/posts/2026/03/more-wonder-and-woe-with-ai.md`
  - Discusses a real-world failure mode when using AI for code generation: building confident, well-tested code on the wrong architectural foundation
  - Key insight: domain knowledge that feels obvious to the developer ("a role IS a group") must be explicitly documented in plans, as AI agents cannot infer unstated context
  - References Eric Evans' _Domain-Driven Design_ (2003) and the concept of Ubiquitous Language as a process for surfacing tacit knowledge
  - Argues for comprehensive upfront planning over iterative discovery cycles
  - Includes metadata, tags (`ai`, `founding-engineer`, `devaiops`, `first-principles`), and LinkedIn excerpt

## Notable Details
- Published date: March 2, 2026
- Continues the series on AI-assisted development (follows "Vibe Coding: Joy and Regret")
- Emphasizes that powerful tools require disciplined operators—the failure was in preparation, not execution

https://claude.ai/code/session_012Dr77GxabL7DRxyHHHfKYz