### PR TITLE
fix: add CloudFront Function for trailing slash URL rewrite

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -55,6 +55,26 @@ Resources:
   # S3 END
 
   # CloudFront START
+  UrlRewriteFunction:
+    Type: AWS::CloudFront::Function
+    Properties:
+      Name: !Sub '${AWS::StackName}-url-rewrite'
+      AutoPublish: true
+      FunctionCode: |
+        function handler(event) {
+            var request = event.request;
+            var uri = request.uri;
+            if (uri.endsWith('/')) {
+                request.uri += 'index.html';
+            } else if (!uri.includes('.')) {
+                request.uri += '/index.html';
+            }
+            return request;
+        }
+      FunctionConfig:
+        Comment: !Sub 'Rewrite URLs to append index.html for ${Domain}'
+        Runtime: cloudfront-js-2.0
+
   WebsiteBucketOAI:
     Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
     Properties:
@@ -107,6 +127,9 @@ Resources:
               - HEAD
               - GET
             CachePolicyId: !GetAtt DefaultCachePolicy.Id
+            FunctionAssociations:
+              - EventType: viewer-request
+                FunctionARN: !GetAtt UrlRewriteFunction.FunctionARN
         DefaultCacheBehavior:
           CachePolicyId: !GetAtt DefaultCachePolicy.Id
           AllowedMethods:
@@ -118,6 +141,9 @@ Resources:
             - GET
           TargetOriginId: WebsiteBucket
           ViewerProtocolPolicy: redirect-to-https
+          FunctionAssociations:
+            - EventType: viewer-request
+              FunctionARN: !GetAtt UrlRewriteFunction.FunctionARN
         ViewerCertificate:
           AcmCertificateArn: !Ref Certificate
           SslSupportMethod: 'sni-only'


### PR DESCRIPTION
## Summary
- Adds a CloudFront Function (viewer-request) that rewrites directory-like URLs to append `/index.html`
- Fixes `AccessDenied` errors when navigating to paths without trailing slashes (e.g. `/experience` vs `/experience/`)
- Attaches the function to both `DefaultCacheBehavior` and the wildcard `CacheBehavior`

## How it works
The function checks the URI:
- If it ends with `/` → appends `index.html`
- If it has no file extension (no `.`) → appends `/index.html`
- Otherwise passes through unchanged

## Deployment
This is an infrastructure change to `template.yaml`. After merge, the SAM stack needs to be deployed (`sam deploy`) to create the CloudFront Function and attach it to the distribution.

## Test plan
- [ ] Deploy SAM stack
- [ ] Verify `/experience` loads correctly (no trailing slash)
- [ ] Verify `/experience/` still works
- [ ] Verify `/` root still works
- [ ] Verify static assets (CSS, JS, images) still load

🤖 Generated with [Claude Code](https://claude.com/claude-code)